### PR TITLE
endpoint: add chrome header support checking user-agent request

### DIFF
--- a/wtransport/src/endpoint.rs
+++ b/wtransport/src/endpoint.rs
@@ -315,14 +315,12 @@ impl SessionRequest {
 
     /// Accepts the client request and it establishes the WebTransport session.
     pub async fn accept(mut self) -> Result<Connection, ConnectionError> {
+        let user_agent = self.user_agent().unwrap_or_default();
+
         let mut response = SessionResponseProto::ok();
 
         // Chrome support
-        if self
-            .headers()
-            .get("sec-webtransport-http3-draft02")
-            .is_some()
-        {
+        if !user_agent.contains("firefox") {
             response.add("sec-webtransport-http3-draft", "draft02");
         }
 
@@ -346,14 +344,12 @@ impl SessionRequest {
 
     /// Rejects the client request by replying with `404` status code.
     pub async fn not_found(mut self) {
+        let user_agent = self.user_agent().unwrap_or_default();
+
         let mut response = SessionResponseProto::not_found();
 
         // Chrome support
-        if self
-            .headers()
-            .get("sec-webtransport-http3-draft02")
-            .is_some()
-        {
+        if !user_agent.contains("firefox") {
             response.add("sec-webtransport-http3-draft", "draft02");
         }
 


### PR DESCRIPTION
Fixes: https://github.com/BiagioFesta/wtransport/issues/17

* Firefox correctly sends `user-agent` in its request.
* Chrome does not.

Exploit that to understand the origin of the request