### PR TITLE
Disable webtransport_max_sessions setting

### DIFF
--- a/wtransport/src/driver/streams/settings.rs
+++ b/wtransport/src/driver/streams/settings.rs
@@ -26,7 +26,7 @@ impl LocalSettingsStream {
             .qpack_blocked_streams(VarInt::from_u32(0))
             .enable_webtransport()
             .enable_h3_datagrams()
-            .webtransport_max_sessions(VarInt::from_u32(1))
+            // .webtransport_max_sessions(VarInt::from_u32(1))
             .build();
 
         Self {


### PR DESCRIPTION
A temporary fix that makes Chrome work again. This is PoC, and a hotfix. It might make sense to do something smarter, so I suggest we don't merge this.

That said, this branch works at Chrome with `https://webtransport.day`.