### PR TITLE
Update wtransport's proto dependency to 0.1.4

### DIFF
--- a/wtransport/Cargo.toml
+++ b/wtransport/Cargo.toml
@@ -28,7 +28,7 @@ thiserror = "1.0.40"
 tokio = { version = "1.28.1", default-features = false, features = ["macros"] }
 tracing = "0.1.37"
 url = "2.4.0"
-wtransport-proto = { version = "0.1.0", path = "../wtransport-proto", features = ["async"] }
+wtransport-proto = { version = "0.1.4", path = "../wtransport-proto", features = ["async"] }
 
 [dev-dependencies]
 anyhow = "1.0.71"


### PR DESCRIPTION
When updating from wtransport 0.1.3 to 0.1.4, my build failed because wtransport used the old version of wtransport-proto (0.1.0). This PR should fix the version mismatch for anyone else updating from 0.1.3 to 0.1.4. wtransport's `-proto` dependency should also probably be kept in line with wtransport's own version.