### PR TITLE
cargo: bump lsqpack version 0.1.2 -> 0.1.3

### DIFF
--- a/wtransport-proto/Cargo.toml
+++ b/wtransport-proto/Cargo.toml
@@ -13,12 +13,12 @@ workspace = ".."
 rust-version = "1.63.0"
 
 [dependencies]
-ls-qpack = "0.1.2"
+ls-qpack = {git = "https://github.com/BiagioFesta/ls-qpack-rs", rev = "82060420bf6f9d432aa48ac7d7eee57e19dba891"}
 octets = "0.2.0"
 url = "2.4.0"
 
 [dev-dependencies]
-tokio = { version = "1.28.1", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.32.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = []

--- a/wtransport-proto/Cargo.toml
+++ b/wtransport-proto/Cargo.toml
@@ -13,12 +13,12 @@ workspace = ".."
 rust-version = "1.63.0"
 
 [dependencies]
-ls-qpack = {git = "https://github.com/BiagioFesta/ls-qpack-rs", rev = "82060420bf6f9d432aa48ac7d7eee57e19dba891"}
+ls-qpack = "0.1.3"
 octets = "0.2.0"
 url = "2.4.0"
 
 [dev-dependencies]
-tokio = { version = "1.32.0", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.28.1", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = []

--- a/wtransport/Cargo.toml
+++ b/wtransport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wtransport"
-version = "0.1.4"
+version = "0.1.5"
 license = "MIT OR Apache-2.0"
 authors = ["Biagio Festa"]
 description = "Implementation of the WebTransport (over HTTP3) protocol"
@@ -28,7 +28,7 @@ thiserror = "1.0.40"
 tokio = { version = "1.28.1", default-features = false, features = ["macros"] }
 tracing = "0.1.37"
 url = "2.4.0"
-wtransport-proto = { version = "0.1.4", path = "../wtransport-proto", features = ["async"] }
+wtransport-proto = { version = "0.1.5", path = "../wtransport-proto", features = ["async"] }
 
 [dev-dependencies]
 anyhow = "1.0.71"


### PR DESCRIPTION
This PR fixes the issue on compiling wtransport on Arm machines.

I have not really heavily tested on my arm machines but the basics works with no apparent issues, I hope it helps.. knowing that there is no runner for ARM on Github action its a bit tedious to test