### PR TITLE
Implement Debug for API types

### DIFF
--- a/wtransport-proto/src/stream.rs
+++ b/wtransport-proto/src/stream.rs
@@ -39,6 +39,7 @@ pub enum IoReadError {
 pub type IoWriteError = bytes::IoWriteError;
 
 /// A QUIC/HTTP3/WebTransport stream.
+#[derive(Debug)]
 pub struct Stream<K, S> {
     kind: K,
     stage: S,
@@ -1067,6 +1068,7 @@ pub mod types {
     }
 
     /// Session (HTTP3-CONNECT) stream type.
+    #[derive(Debug)]
     pub struct Session {
         session_request: SessionRequest,
     }
@@ -1084,18 +1086,23 @@ pub mod types {
     }
 
     /// Bidirectional stream type.
+    #[derive(Debug)]
     pub struct Bi;
 
     /// Unidirectional stream type.
+    #[derive(Debug)]
     pub struct Uni;
 
     /// Remote-initialized stream type.
+    #[derive(Debug)]
     pub struct Remote;
 
     /// Local-initialized stream type.
+    #[derive(Debug)]
     pub struct Local;
 
     /// Remote-initialized bi-directional stream type.
+    #[derive(Debug)]
     pub struct BiRemote(Bi, Remote);
 
     impl Default for BiRemote {

--- a/wtransport/src/connection.rs
+++ b/wtransport/src/connection.rs
@@ -13,6 +13,7 @@ use wtransport_proto::ids::SessionId;
 use wtransport_proto::varint::VarInt;
 
 /// A WebTransport session connection.
+#[derive(Debug)]
 pub struct Connection {
     quic_connection: quinn::Connection,
     driver: Driver,

--- a/wtransport/src/datagram.rs
+++ b/wtransport/src/datagram.rs
@@ -6,6 +6,7 @@ use wtransport_proto::ids::QStreamId;
 use wtransport_proto::ids::SessionId;
 
 /// An application Datagram.
+#[derive(Debug)]
 pub struct Datagram {
     quic_dgram: Bytes,
     payload_offset: usize,

--- a/wtransport/src/driver/mod.rs
+++ b/wtransport/src/driver/mod.rs
@@ -32,6 +32,7 @@ pub enum DriverError {
     NotConnected,
 }
 
+#[derive(Debug)]
 pub struct Driver {
     quic_connection: quinn::Connection,
     ready_settings: Mutex<mpsc::Receiver<Settings>>,

--- a/wtransport/src/driver/streams/mod.rs
+++ b/wtransport/src/driver/streams/mod.rs
@@ -25,6 +25,7 @@ pub type ProtoWriteError = wtransport_proto::stream::IoWriteError;
 #[derive(Debug)]
 pub struct AlreadyStop;
 
+#[derive(Debug)]
 pub struct QuicSendStream(quinn::SendStream);
 
 impl QuicSendStream {
@@ -129,6 +130,7 @@ impl tokio::io::AsyncWrite for QuicSendStream {
     }
 }
 
+#[derive(Debug)]
 pub struct QuicRecvStream(quinn::RecvStream);
 
 impl QuicRecvStream {
@@ -193,6 +195,7 @@ impl tokio::io::AsyncRead for QuicRecvStream {
     }
 }
 
+#[derive(Debug)]
 pub struct Stream<S, P> {
     stream: S,
     proto: P,

--- a/wtransport/src/driver/utils.rs
+++ b/wtransport/src/driver/utils.rs
@@ -42,7 +42,7 @@ where
     (set, get)
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct SharedResultSet<T>(Arc<watch::Sender<Option<T>>>);
 
 impl<T> SharedResultSet<T>
@@ -87,6 +87,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct SharedResultGet<T>(Mutex<watch::Receiver<Option<T>>>);
 
 impl<T> SharedResultGet<T>
@@ -122,6 +123,7 @@ pub enum TrySendError<T> {
     Closed(T),
 }
 
+#[derive(Debug)]
 pub struct BiChannelEndpoint<T> {
     sender: mpsc::Sender<T>,
     receiver: Mutex<mpsc::Receiver<T>>,

--- a/wtransport/src/stream.rs
+++ b/wtransport/src/stream.rs
@@ -17,6 +17,7 @@ use wtransport_proto::stream_header::StreamHeader;
 use wtransport_proto::varint::VarInt;
 
 /// A stream that can only be used to send data.
+#[derive(Debug)]
 pub struct SendStream(QuicSendStream);
 
 impl SendStream {
@@ -94,6 +95,7 @@ impl SendStream {
 }
 
 /// A stream that can only be used to receive data.
+#[derive(Debug)]
 pub struct RecvStream(QuicRecvStream);
 
 impl RecvStream {


### PR DESCRIPTION
This allows clients to automatically derive Debug for types which embed wtransport types.

Fixes #58