### PR TITLE
Allow "WebSocket" and "WebTransport" without backticks in doc comments.

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = ["WebSocket", "WebTransport", ".."]


### PR DESCRIPTION
Without this configuration, clippy's `doc-markdown` lint will warn about this not being enclosed in backticks.