### PR TITLE
nit: Missing semicolon.

### DIFF
--- a/wtransport/src/config.rs
+++ b/wtransport/src/config.rs
@@ -756,7 +756,7 @@ mod utils {
     impl Drop for VarRestoreGuard {
         fn drop(&mut self) {
             if let Some(value) = self.value.take() {
-                env::set_var(self.key.clone(), value)
+                env::set_var(self.key.clone(), value);
             }
         }
     }


### PR DESCRIPTION
Nothing is returned, so we should use a semicolon.