### PR TITLE
Allow rejecting incoming session with forbidden.

### DIFF
--- a/wtransport-proto/src/ids.rs
+++ b/wtransport-proto/src/ids.rs
@@ -256,6 +256,9 @@ impl StatusCode {
     /// HTTP 200 OK status code.
     pub const OK: Self = Self(200);
 
+    /// HTTP 403 Forbidden status code.
+    pub const FORBIDDEN: Self = Self(403);
+
     /// HTTP 404 Not Found status code.
     pub const NOT_FOUND: Self = Self(404);
 

--- a/wtransport-proto/src/session.rs
+++ b/wtransport-proto/src/session.rs
@@ -223,6 +223,11 @@ impl SessionResponse {
         Self::with_status_code(StatusCode::OK)
     }
 
+    /// Constructs with [`StatusCode::FORBIDDEN`].
+    pub fn forbidden() -> Self {
+        Self::with_status_code(StatusCode::FORBIDDEN)
+    }
+
     /// Constructs with [`StatusCode::NOT_FOUND`].
     pub fn not_found() -> Self {
         Self::with_status_code(StatusCode::NOT_FOUND)


### PR DESCRIPTION
This is allowed in the current specification for when validating `ORIGIN` and deciding to reject the request.