### PR TITLE
TLS module refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ It should be used with caution and may undergo changes as the WebTransport speci
 async fn main() -> Result<()> {
     let config = ServerConfig::builder()
         .with_bind_default(4433)
-        .with_certificate(certificate)
+        .with_identity(&identity)
         .build();
 
     let connection = Endpoint::server(config)?

--- a/wtransport/Cargo.toml
+++ b/wtransport/Cargo.toml
@@ -31,7 +31,8 @@ rcgen = { version = "0.12.0", optional = true }
 ring = { version = "0.17.7", optional = true }
 rustls = "0.21.1"
 rustls-native-certs = "0.6.2"
-rustls-pemfile = "1.0.2"
+rustls-pemfile = "2.1.1"
+rustls-pki-types = "1.3.1"
 socket2 = "0.5.3"
 thiserror = "1.0.40"
 time = { version = "0.3.21", optional = true }

--- a/wtransport/examples/server.rs
+++ b/wtransport/examples/server.rs
@@ -7,8 +7,8 @@ use tracing::Instrument;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::EnvFilter;
 use wtransport::endpoint::IncomingSession;
-use wtransport::Certificate;
 use wtransport::Endpoint;
+use wtransport::Identity;
 use wtransport::ServerConfig;
 
 #[tokio::main]
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
 
     let config = ServerConfig::builder()
         .with_bind_default(4433)
-        .with_certificate(Certificate::self_signed(["localhost"]))
+        .with_identity(&Identity::self_signed(["localhost"]))
         .keep_alive_interval(Some(Duration::from_secs(3)))
         .build();
 

--- a/wtransport/src/endpoint.rs
+++ b/wtransport/src/endpoint.rs
@@ -69,13 +69,13 @@ pub mod endpoint_side {
 /// ```no_run
 /// # use anyhow::Result;
 /// # use wtransport::ServerConfig;
-/// # use wtransport::Certificate;
+/// # use wtransport::Identity;
 /// use wtransport::Endpoint;
 ///
 /// # async fn run() -> Result<()> {
 /// # let config = ServerConfig::builder()
 /// #       .with_bind_default(4433)
-/// #       .with_certificate(Certificate::load("cert.pem", "key.pem").await?)
+/// #       .with_identity(&Identity::self_signed(["doc"]))
 /// #       .build();
 /// let server = Endpoint::server(config)?;
 /// loop {
@@ -92,7 +92,6 @@ pub mod endpoint_side {
 ///
 /// ```no_run
 /// # use anyhow::Result;
-/// # use wtransport::Certificate;
 /// use wtransport::ClientConfig;
 /// use wtransport::Endpoint;
 ///

--- a/wtransport/src/lib.rs
+++ b/wtransport/src/lib.rs
@@ -44,15 +44,15 @@
 //! ## Server
 //! ```no_run
 //! # use anyhow::Result;
-//! use wtransport::Certificate;
 //! use wtransport::Endpoint;
+//! use wtransport::Identity;
 //! use wtransport::ServerConfig;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
 //!     let config = ServerConfig::builder()
 //!         .with_bind_default(4433)
-//!         .with_certificate(Certificate::load("cert.pem", "key.pem").await?)
+//!         .with_identity(&Identity::load_pemfiles("cert.pem", "key.pem").await?)
 //!         .build();
 //!
 //!     let server = Endpoint::server(config)?;
@@ -116,7 +116,7 @@ pub use config::ClientConfig;
 pub use config::ServerConfig;
 
 #[doc(inline)]
-pub use tls::Certificate;
+pub use tls::Identity;
 
 #[doc(inline)]
 pub use endpoint::Endpoint;


### PR DESCRIPTION
--- **This breaks API compatibility** ---

### Before
* `Certificate` was the union of a certificate chain and a private key.

```
use wtransport::Certificate;

 let config = ServerConfig::builder()
        .with_bind_default(4433)
        .with_certificate(certificate)
        .build();
```

### After
Now stuff should be clearer,
* `Certificate` is just a single x509 certificate (which implements `Debug`)
* `Private Key` is a single private key.
* `Identity` is aggregation of multiple certificates (certificate chain) and a private key
  - `Identity` implements `Debug` without leaking the private key.

```
use wtransport::Identity;

 let config = ServerConfig::builder()
        .with_bind_default(4433)
        .with_identity(&identity)
        .build();
```
