### PR TITLE
Fix #163 - add `SessionRequest::too_many_requests()`.

### DIFF
--- a/wtransport-proto/src/ids.rs
+++ b/wtransport-proto/src/ids.rs
@@ -265,6 +265,9 @@ impl StatusCode {
     /// HTTP 404 Not Found status code.
     pub const NOT_FOUND: Self = Self(404);
 
+    /// HTTP 429 Too Many Requests status code.
+    pub const TOO_MANY_REQUESTS: Self = Self(429);
+
     /// Tries to construct from `u32`.
     #[inline(always)]
     pub fn try_from_u32(value: u32) -> Result<Self, InvalidStatusCode> {

--- a/wtransport-proto/src/session.rs
+++ b/wtransport-proto/src/session.rs
@@ -302,6 +302,11 @@ impl SessionResponse {
         Self::with_status_code(StatusCode::NOT_FOUND)
     }
 
+    /// Constructs with [`StatusCode::TOO_MANY_REQUESTS`].
+    pub fn too_many_requests() -> Self {
+        Self::with_status_code(StatusCode::TOO_MANY_REQUESTS)
+    }
+
     /// Returns the status code.
     pub fn code(&self) -> StatusCode {
         self.0

--- a/wtransport/src/endpoint.rs
+++ b/wtransport/src/endpoint.rs
@@ -688,6 +688,11 @@ impl SessionRequest {
         self.reject(SessionResponseProto::not_found()).await;
     }
 
+    /// Rejects the client request by replying with `429` status code.
+    pub async fn too_many_requests(self) {
+        self.reject(SessionResponseProto::too_many_requests()).await;
+    }
+
     async fn reject(mut self, mut response: SessionResponseProto) {
         let user_agent = self.user_agent().unwrap_or_default();
 


### PR DESCRIPTION
Fixes #163 by allowing HTTP 429 rejection.

## Testing

`cargo build` works. I didn't test it, per se.