### PR TITLE
Fix #165 - document that IPv4 addresses from `remote_address` may be mapped to IPv6.

### DIFF
--- a/wtransport/src/connection.rs
+++ b/wtransport/src/connection.rs
@@ -317,7 +317,8 @@ impl Connection {
     /// Returns the peer's UDP address.
     ///
     /// **Note**: as QUIC supports migration, remote address may change
-    /// during connection.
+    /// during connection. Furthermore, when IPv6 support is enabled, IPv4
+    /// addresses may be mapped to IPv6.
     #[inline(always)]
     pub fn remote_address(&self) -> SocketAddr {
         self.quic_connection.remote_address()

--- a/wtransport/src/endpoint.rs
+++ b/wtransport/src/endpoint.rs
@@ -627,7 +627,8 @@ impl SessionRequest {
     /// Returns the peer's UDP address.
     ///
     /// **Note**: as QUIC supports migration, remote address may change
-    /// during connection.
+    /// during connection. Furthermore, when IPv6 support is enabled, IPv4
+    /// addresses may be mapped to IPv6.
     #[inline(always)]
     pub fn remote_address(&self) -> SocketAddr {
         self.quic_connection.remote_address()


### PR DESCRIPTION
Fixes #165 