### PR TITLE
CertificateHash without self-signed feature

### DIFF
--- a/wtransport/Cargo.toml
+++ b/wtransport/Cargo.toml
@@ -33,7 +33,7 @@ bytes = "1.4.0"
 pem = "3.0.4"
 quinn = "0.10.1"
 rcgen = { version = "0.13.1", optional = true }
-ring = { version = "0.17.7", optional = true }
+ring = "0.17.7"
 rustls = { version = "0.21.1", features = ["dangerous_configuration"] }
 rustls-native-certs = "0.6.2"
 rustls-pemfile = "2.1.1"
@@ -56,9 +56,9 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [features]
 default = ["self-signed"]
-dangerous-configuration = []
+dangerous-configuration = ["dep:time"]
 quinn = []
-self-signed = ["dep:rcgen", "dep:time", "dep:ring"]
+self-signed = ["dep:rcgen", "dep:time"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wtransport/Cargo.toml
+++ b/wtransport/Cargo.toml
@@ -33,11 +33,11 @@ bytes = "1.4.0"
 pem = "3.0.4"
 quinn = "0.10.1"
 rcgen = { version = "0.13.1", optional = true }
-ring = "0.17.7"
 rustls = { version = "0.21.1", features = ["dangerous_configuration"] }
 rustls-native-certs = "0.6.2"
 rustls-pemfile = "2.1.1"
 rustls-pki-types = "1.3.1"
+sha2 = "0.10.8"
 socket2 = "0.5.3"
 thiserror = "1.0.40"
 time = { version = "0.3.21", optional = true }

--- a/wtransport/src/config.rs
+++ b/wtransport/src/config.rs
@@ -743,11 +743,8 @@ impl ClientConfigBuilder<states::WantsRootStore> {
     /// - The current time MUST be within the validity period of the certificate.
     /// - The total length of the validity period MUST NOT exceed *two* weeks.
     /// - Only certificates for which the public key algorithm is *ECDSA* with the *secp256r1* are accepted.
-    #[cfg(all(feature = "dangerous-configuration", feature = "self-signed"))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(all(feature = "dangerous-configuration", feature = "self-signed")))
-    )]
+    #[cfg(feature = "dangerous-configuration")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dangerous-configuration")))]
     pub fn with_server_certificate_hashes<I>(
         self,
         hashes: I,

--- a/wtransport/src/tls.rs
+++ b/wtransport/src/tls.rs
@@ -3,6 +3,8 @@ use error::InvalidDigest;
 use error::PemLoadError;
 use pem::encode as pem_encode;
 use pem::Pem;
+use ring::digest::digest;
+use ring::digest::SHA256;
 use rustls::RootCertStore;
 use rustls_pki_types::CertificateDer;
 use rustls_pki_types::PrivateKeyDer;
@@ -57,12 +59,7 @@ impl Certificate {
     /// certificate by using the [`WebTransportOptions.serverCertificateHashes`] W3C API.
     ///
     /// [`WebTransportOptions.serverCertificateHashes`]: https://www.w3.org/TR/webtransport/#dom-webtransportoptions-servercertificatehashes
-    #[cfg(feature = "self-signed")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "self-signed")))]
     pub fn hash(&self) -> Sha256Digest {
-        use ring::digest::digest;
-        use ring::digest::SHA256;
-
         Sha256Digest(
             digest(&SHA256, &self.0)
                 .as_ref()
@@ -664,13 +661,10 @@ pub mod client {
     /// - The current time MUST be within the validity period of the certificate.
     /// - The total length of the validity period MUST NOT exceed *two* weeks.
     /// - Only certificates for which the public key algorithm is *ECDSA* with the *secp256r1* are accepted.
-    #[cfg(feature = "self-signed")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "self-signed")))]
     pub struct ServerHashVerification {
         hashes: std::collections::BTreeSet<Sha256Digest>,
     }
 
-    #[cfg(feature = "self-signed")]
     impl ServerHashVerification {
         const SELF_MAX_VALIDITY: time::Duration = time::Duration::days(14);
 
@@ -692,7 +686,6 @@ pub mod client {
         }
     }
 
-    #[cfg(feature = "self-signed")]
     impl ServerCertVerifier for ServerHashVerification {
         fn verify_server_cert(
             &self,

--- a/wtransport/src/tls.rs
+++ b/wtransport/src/tls.rs
@@ -3,12 +3,12 @@ use error::InvalidDigest;
 use error::PemLoadError;
 use pem::encode as pem_encode;
 use pem::Pem;
-use ring::digest::digest;
-use ring::digest::SHA256;
 use rustls::RootCertStore;
 use rustls_pki_types::CertificateDer;
 use rustls_pki_types::PrivateKeyDer;
 use rustls_pki_types::PrivatePkcs8KeyDer;
+use sha2::Digest;
+use sha2::Sha256;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::path::Path;
@@ -60,12 +60,10 @@ impl Certificate {
     ///
     /// [`WebTransportOptions.serverCertificateHashes`]: https://www.w3.org/TR/webtransport/#dom-webtransportoptions-servercertificatehashes
     pub fn hash(&self) -> Sha256Digest {
-        Sha256Digest(
-            digest(&SHA256, &self.0)
-                .as_ref()
-                .try_into()
-                .expect("SHA256 digest is 32 bytes len"),
-        )
+        // TODO(biagio): you might consider use crypto provider from new rustls version
+        let mut sha256 = Sha256::new();
+        sha256.update(self.der());
+        Sha256Digest(sha256.finalize().into())
     }
 }
 


### PR DESCRIPTION
Removes `self-signed` feature for `with_server_certificate_hashes` TLS configuration.

This forces inclusion of `ring` dep

We might consider to change `dangerous` feature name in next dev