### PR TITLE
fix: time dep is no more optional

### DIFF
--- a/wtransport/Cargo.toml
+++ b/wtransport/Cargo.toml
@@ -40,7 +40,7 @@ rustls-pki-types = "1.3.1"
 sha2 = "0.10.8"
 socket2 = "0.5.3"
 thiserror = "1.0.40"
-time = { version = "0.3.21", optional = true }
+time = "0.3.21"
 tokio = { version = "1.28.1", default-features = false, features = ["macros", "fs", "io-util"] }
 tracing = "0.1.37"
 url = "2.4.0"
@@ -56,9 +56,9 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [features]
 default = ["self-signed"]
-dangerous-configuration = ["dep:time"]
+dangerous-configuration = []
 quinn = []
-self-signed = ["dep:rcgen", "dep:time"]
+self-signed = ["dep:rcgen"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This fixes the compilation process when no-default-features is specified

Fixes: https://github.com/BiagioFesta/wtransport/issues/180