### PR TITLE
Implement Eq, PartialEq, Clone for errors when possible

### DIFF
--- a/wtransport-proto/src/error.rs
+++ b/wtransport-proto/src/error.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 
 /// HTTP3 protocol errors.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub enum ErrorCode {
     /// `H3_DATAGRAM_ERROR`.
     Datagram,

--- a/wtransport/src/error.rs
+++ b/wtransport/src/error.rs
@@ -7,7 +7,7 @@ use std::net::SocketAddr;
 use wtransport_proto::error::ErrorCode;
 
 /// An enumeration representing various errors that can occur during a WebTransport connection.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone, Eq, PartialEq)]
 pub enum ConnectionError {
     /// The connection was aborted by the peer (protocol level).
     #[error("connection aborted by peer: {0}")]
@@ -136,7 +136,7 @@ impl ConnectingError {
 }
 
 /// An error that arise from writing to a stream.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone, Eq, PartialEq)]
 pub enum StreamWriteError {
     /// Connection has been dropped.
     #[error("not connected")]
@@ -152,7 +152,7 @@ pub enum StreamWriteError {
 }
 
 /// An error that arise from reading from a stream.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone, Eq, PartialEq)]
 pub enum StreamReadError {
     /// Connection has been dropped.
     #[error("not connected")]
@@ -168,7 +168,7 @@ pub enum StreamReadError {
 }
 
 /// An error that arise from reading from a stream.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum StreamReadExactError {
     /// The stream finished before all bytes were read.
     #[error("stream finished too early")]
@@ -180,7 +180,7 @@ pub enum StreamReadExactError {
 }
 
 /// An error that arise from sending a datagram.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone, Eq, PartialEq)]
 pub enum SendDatagramError {
     /// Connection has been dropped.
     #[error("not connected")]
@@ -196,7 +196,7 @@ pub enum SendDatagramError {
 }
 
 /// An error that arise when opening a new stream.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone, Eq, PartialEq)]
 pub enum StreamOpeningError {
     /// Connection has been dropped.
     #[error("not connected")]
@@ -208,7 +208,7 @@ pub enum StreamOpeningError {
 }
 
 /// Reason given by an application for closing the connection
-#[derive(Debug)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ApplicationClose {
     code: VarInt,
     reason: Box<[u8]>,
@@ -229,7 +229,7 @@ impl Display for ApplicationClose {
 }
 
 /// Reason given by the transport for closing the connection.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConnectionClose(quinn::ConnectionClose);
 
 impl Display for ConnectionClose {
@@ -239,7 +239,7 @@ impl Display for ConnectionClose {
 }
 
 /// A struct representing an error in the HTTP3 layer.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct H3Error {
     code: ErrorCode,
 }
@@ -283,7 +283,7 @@ impl From<quinn::ConnectionError> for ConnectionError {
 }
 
 /// A complete specification of an error over QUIC protocol.
-#[derive(Debug)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct QuicProtoError {
     code: Option<VarInt>,
     reason: Cow<'static, str>,
@@ -303,6 +303,6 @@ impl Display for QuicProtoError {
 /// Error returned by [`Connection::export_keying_material`](crate::Connection::export_keying_material).
 ///
 /// This error occurs if the requested output length is too large.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Clone, Eq, PartialEq)]
 #[error("cannot derive keying material as requested output length is too large")]
 pub struct ExportKeyingMaterialError;


### PR DESCRIPTION
Overall this should improve the ergonomics of error handling. Eq/PartialEq is very useful for comparing errors with == instead of match statements. And Clone is necessary when needing to store an error (such as from a task), and repeatedly return it to the caller (such as when the struct is now poisoned to due a failed task).

<details>
<summary>More detail on why I needed this</summary>

I had a struct that communicated over channels to a tokio task. It would send and receive messages on a wtransport stream. If the task crashed due to a wtransport error, I returned the error via a tokio JoinHandle. 

In the struct when sending a message, if it detected that the task had died, it would return an error to the caller. I wanted to return the actual real error from wtransport, but that would require me to be able to clone the error each time. Since wtransport didn't support that, I had to use a different less explanatory error instead. You can see my code [here](https://github.com/NexusSocial/nexus-vr/pull/113/files) if you are morbidly curious :)
</details>