### PR TITLE
add methods for custom transport configuration

### DIFF
--- a/wtransport/Cargo.toml
+++ b/wtransport/Cargo.toml
@@ -74,6 +74,7 @@ allowed_external_types = [
     "quinn::send_stream::WriteError",
     "quinn_proto::config::ClientConfig",
     "quinn_proto::config::ServerConfig",
+    "quinn_proto::config::TransportConfig",
     "quinn_proto::connection::ConnectionError",
     "rustls",
     "rustls::anchors::RootCertStore",


### PR DESCRIPTION
## Description

This pull request introduces two new methods to the `ServerConfigBuilder`:

1. **`with_custom_transport`**: Allows configuration of a server with a custom transport setup while using a default TLS configuration generated from an `Identity`. This method provides flexibility for users who need to customize transport settings without manually configuring TLS.

2. **`with_custom_tls_and_transport`**: Enables full customization of both TLS and transport settings. Users can pass a preconfigured `TlsServerConfig` and a custom `TransportConfig` to fine-tune both layers of the server configuration. This is particularly useful for advanced scenarios where specific TLS and transport requirements are necessary.

### Documentation and Examples

Both methods come with comprehensive documentation and usage examples to help users understand how to implement and use these configurations effectively.

### Motivation

While attempting to modify the `datagram_send_buffer_size` in `TransportConfig`, I noticed that even though there is a `pub fn quic_connection_mut(&mut self) -> &mut quinn::Connection` method, the `TransportConfig` is encapsulated within an `Arc`, which does not provide internal mutability through locking. As a result, even with a mutable reference, it is impossible to change its member variables directly. This limitation highlighted the need for additional methods to allow full customization of both TLS and transport configurations. These new methods are particularly useful for users who need to modify the `TransportConfig` or similar settings.