### PR TITLE
Upgrade to `rustls@0.23` and `quinn@0.11`

### DIFF
--- a/wtransport/Cargo.toml
+++ b/wtransport/Cargo.toml
@@ -31,12 +31,12 @@ required-features = ["self-signed"]
 [dependencies]
 bytes = "1.4.0"
 pem = "3.0.4"
-quinn = "0.10.1"
+quinn = { version = "0.11.3", default-features = false, features = ["runtime-tokio", "rustls"] }
 rcgen = { version = "0.13.1", optional = true }
-rustls = { version = "0.21.1", features = ["dangerous_configuration"] }
+rustls = { version = "0.23.12", default-features = false, features = ["ring"] }
 rustls-native-certs = "0.7.1"
-rustls-pemfile = "2.1.1"
-rustls-pki-types = "1.3.1"
+rustls-pemfile = "2.1.3"
+rustls-pki-types = "1.8.0"
 sha2 = "0.10.8"
 socket2 = "0.5.3"
 thiserror = "1.0.40"
@@ -58,6 +58,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 default = ["self-signed"]
 dangerous-configuration = []
 quinn = []
+quinn-log = ["quinn/log"]
 self-signed = ["dep:rcgen"]
 
 [package.metadata.docs.rs]
@@ -77,7 +78,7 @@ allowed_external_types = [
     "quinn_proto::config::TransportConfig",
     "quinn_proto::connection::ConnectionError",
     "rustls",
-    "rustls::anchors::RootCertStore",
+    "rustls::webpki::anchors::RootCertStore",
     "rustls::client::client_conn::ClientConfig",
     "rustls::server::server_conn::ServerConfig",
     "rustls::verify::ServerCertVerifier",

--- a/wtransport/src/connection.rs
+++ b/wtransport/src/connection.rs
@@ -382,10 +382,10 @@ impl Connection {
     /// is not available, `None` is returned.
     pub fn peer_identity(&self) -> Option<CertificateChain> {
         self.quic_connection.peer_identity().map(|any| {
-            any.downcast::<Vec<rustls::Certificate>>()
+            any.downcast::<Vec<rustls_pki_types::CertificateDer<'static>>>()
                 .expect("rustls certificate vector")
                 .into_iter()
-                .map(|c| Certificate::from_der(c.0).expect("valid certificate"))
+                .map(Certificate::from_rustls_pki)
                 .collect()
         })
     }

--- a/wtransport/src/driver/streams/qpack.rs
+++ b/wtransport/src/driver/streams/qpack.rs
@@ -39,7 +39,7 @@ impl RemoteQPackEncStream {
         loop {
             match stream.stream_mut().read_exact(&mut self.buffer).await {
                 Ok(()) => {}
-                Err(StreamReadExactError::FinishedEarly) => {
+                Err(StreamReadExactError::FinishedEarly(_)) => {
                     return DriverError::Proto(ErrorCode::ClosedCriticalStream);
                 }
                 Err(StreamReadExactError::Read(StreamReadError::NotConnected)) => {
@@ -88,7 +88,7 @@ impl RemoteQPackDecStream {
         loop {
             match stream.stream_mut().read_exact(&mut self.buffer).await {
                 Ok(()) => {}
-                Err(StreamReadExactError::FinishedEarly) => {
+                Err(StreamReadExactError::FinishedEarly(_)) => {
                     return DriverError::Proto(ErrorCode::ClosedCriticalStream);
                 }
                 Err(StreamReadExactError::Read(StreamReadError::NotConnected)) => {

--- a/wtransport/src/driver/streams/settings.rs
+++ b/wtransport/src/driver/streams/settings.rs
@@ -65,7 +65,9 @@ impl LocalSettingsStream {
         match self.stream.as_mut() {
             Some(stream) => match stream.stopped().await {
                 StreamWriteError::NotConnected => DriverError::NotConnected,
-                StreamWriteError::Stopped(_) => DriverError::Proto(ErrorCode::ClosedCriticalStream),
+                StreamWriteError::Closed | StreamWriteError::Stopped(_) => {
+                    DriverError::Proto(ErrorCode::ClosedCriticalStream)
+                }
                 StreamWriteError::QuicProto => DriverError::Proto(ErrorCode::ClosedCriticalStream),
             },
             None => pending().await,


### PR DESCRIPTION
Fixes #121
Fixes #175
Supersedes #194 

I'm still new to `wtransport`, `quinn`, and `rustls`; this PR should be scrutinized for errors.

## Testing
- [x] CI
- [x] ran client & server examples
- [x] testing in my application (localhost)
- [x] testing in my application (prod)
<details>
<summary>production deployments</summary>

- [x] turnfight.com (Aug 18)
- [ ] mazean.com
</details>

## Changelog entries
```
- deps: update to quinn 0.11 and disable some default features by @finnbear in #200
- deps: update to rustls 0.23 and disable some default features by @finnbear in #200
- deps: update to rustls-pki-types 1.8 by @finnbear in #200
- Make `SendStream::reset` take a reference instead of ownership by @finnbear in #200
- docs: calling `priority` or `reset` after `reset` results in panic by @finnbear in #200
- Remove `Endpoint::reject_new_connections` by @finnbear in #200
- Add `Endpoint::open_connections` by @finnbear in #200
- Add multiple methods for `IncomingSession` for server, usable prior to awaiting it, to replace `quinn`'s `max_concurrent_connections`, `use_retry`, and `reject_new_connections` by @finnbear
- Add `ServerConfigBuilder::token_key` to avoid randomizing retry key each config reload by @finnbear
- Add `ConnectionError::CidsExhausted` by @finnbear in #200
- Rename `ConnectingError::TooManyConnections` to `ConnectingError::CidsExhausted` by @finnbear in #200
- Rename `ConnectingError::InvalidDnsName` to `ConnectingError::InvalidServerName` by @finnbear in #200
- Add the number of bytes read to `StreamReadExactError::FinishedEarly` by @finnbear in #200
- docs: `with_custom_tls{_and_transport}` require TLS 1.3 support by @finnbear in #200
```