### PR TITLE
config/server: add `token_key` to avoid randomization of handshake token

### DIFF
--- a/wtransport/Cargo.toml
+++ b/wtransport/Cargo.toml
@@ -77,6 +77,7 @@ allowed_external_types = [
     "quinn_proto::config::ServerConfig",
     "quinn_proto::config::TransportConfig",
     "quinn_proto::connection::ConnectionError",
+    "quinn_proto::crypto::HandshakeTokenKey",
     "rustls",
     "rustls::webpki::anchors::RootCertStore",
     "rustls::client::client_conn::ClientConfig",


### PR DESCRIPTION
## Motivation
To refresh TLS certificates, the `Endpoint` config must be reloaded. If the new config has a different (random) handshake token, then best case in-flight retries will fail. Worst case (as in my application), the *next* retry will fail regardless of when it happens.

## Testing
- [x] my application, via #200 
- [x] my application, via this PR

## Changelog entry
```
- Add `ServerConfigBuilder::token_key` to avoid randomizing handshake token key by @finnbear in #201
```

## Context
Followup to #200

Example code for generating a handshake token:
```rust
fn generate_token_key() -> Arc<dyn quinn_proto::crypto::HandshakeTokenKey> {
    use rand::RngCore;
    let rng = &mut rand::thread_rng();
    let mut master_key = [0u8; 64];
    rng.fill_bytes(&mut master_key);
    let master_key = ring::hkdf::Salt::new(ring::hkdf::HKDF_SHA256, &[]).extract(&master_key);
    std::sync::Arc::new(master_key)
}
```

## Unresolved questions
1. ~~should the example code be included in the docs?~~
2. ~~should the example code be exposed from the API? (would require `ring` and `rand` deps, but they could be optional)~~
3. ~~or should I PR `quinn-proto` to include it there?~~