### PR TITLE
Configuration simplification

### DIFF
--- a/wtransport/src/config.rs
+++ b/wtransport/src/config.rs
@@ -226,7 +226,7 @@ pub struct InvalidIdleTimeout;
 ///     .build();
 /// # Ok(())
 /// # }
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ServerConfig {
     pub(crate) bind_address: SocketAddr,
     pub(crate) dual_stack_config: Ipv6DualStackConfig,
@@ -676,12 +676,12 @@ impl ServerConfigBuilder<states::WantsTransportConfigServer> {
 ///     .keep_alive_interval(Some(Duration::from_secs(3)))
 ///     .build();
 /// ```
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ClientConfig {
     pub(crate) bind_address: SocketAddr,
     pub(crate) dual_stack_config: Ipv6DualStackConfig,
     pub(crate) quic_config: quinn::ClientConfig,
-    pub(crate) dns_resolver: Box<dyn DnsResolver>,
+    pub(crate) dns_resolver: Arc<dyn DnsResolver>,
 }
 
 impl ClientConfig {
@@ -699,7 +699,7 @@ impl ClientConfig {
     where
         R: DnsResolver + 'static,
     {
-        self.dns_resolver = Box::new(dns_resolver);
+        self.dns_resolver = Arc::new(dns_resolver);
     }
 
     /// Returns a reference to the inner QUIC configuration.
@@ -980,7 +980,7 @@ impl ClientConfigBuilder<states::WantsRootStore> {
             bind_address: self.0.bind_address,
             dual_stack_config: self.0.dual_stack_config,
             quic_config,
-            dns_resolver: Box::<TokioDnsResolver>::default(),
+            dns_resolver: Arc::<TokioDnsResolver>::default(),
         }
     }
 
@@ -994,7 +994,7 @@ impl ClientConfigBuilder<states::WantsRootStore> {
             dual_stack_config: self.0.dual_stack_config,
             tls_config,
             transport_config,
-            dns_resolver: Box::<TokioDnsResolver>::default(),
+            dns_resolver: Arc::<TokioDnsResolver>::default(),
         })
     }
 }
@@ -1061,7 +1061,7 @@ impl ClientConfigBuilder<states::WantsTransportConfigClient> {
     where
         R: DnsResolver + 'static,
     {
-        self.0.dns_resolver = Box::new(dns_resolver);
+        self.0.dns_resolver = Arc::new(dns_resolver);
         self
     }
 }
@@ -1112,7 +1112,7 @@ pub mod states {
         pub(super) dual_stack_config: Ipv6DualStackConfig,
         pub(super) tls_config: TlsClientConfig,
         pub(super) transport_config: quinn::TransportConfig,
-        pub(super) dns_resolver: Box<dyn DnsResolver>,
+        pub(super) dns_resolver: Arc<dyn DnsResolver>,
     }
 }
 

--- a/wtransport/src/config.rs
+++ b/wtransport/src/config.rs
@@ -228,6 +228,7 @@ pub struct InvalidIdleTimeout;
 ///     .build();
 /// # Ok(())
 /// # }
+#[derive(Debug)]
 pub struct ServerConfig {
     pub(crate) bind_address: SocketAddr,
     pub(crate) dual_stack_config: Ipv6DualStackConfig,
@@ -677,6 +678,7 @@ impl ServerConfigBuilder<states::WantsTransportConfigServer> {
 ///     .keep_alive_interval(Some(Duration::from_secs(3)))
 ///     .build();
 /// ```
+#[derive(Debug)]
 pub struct ClientConfig {
     pub(crate) bind_address: SocketAddr,
     pub(crate) dual_stack_config: Ipv6DualStackConfig,
@@ -1119,7 +1121,7 @@ pub mod states {
 /// A trait for asynchronously resolving domain names to IP addresses using DNS.
 ///
 /// Utilities for working with `DnsResolver` values are provided by [`DnsResolverExt`].
-pub trait DnsResolver {
+pub trait DnsResolver: Debug {
     /// Resolves a domain name to one IP address.
     fn poll_resolve(
         self: Pin<&mut Self>,
@@ -1191,6 +1193,12 @@ impl DnsResolver for TokioDnsResolver {
         });
 
         Future::poll(fut.as_mut(), cx)
+    }
+}
+
+impl Debug for TokioDnsResolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokioDnsResolver").finish()
     }
 }
 

--- a/wtransport/src/endpoint.rs
+++ b/wtransport/src/endpoint.rs
@@ -52,7 +52,7 @@ pub mod endpoint_side {
     ///
     /// Use [`Endpoint::client`] to create and client-endpoint.
     pub struct Client {
-        pub(super) dns_resolver: Box<dyn DnsResolver>,
+        pub(super) dns_resolver: Arc<dyn DnsResolver>,
     }
 }
 


### PR DESCRIPTION
This PR aims to simplify (and minimize) `wtransport` configurations (both server and client).

In particular, it gives the possibility to configure a server and client directly passing the underlying transport configuration (i.e., `quinn`). This follows the same approach adopted for the underlying TLS stack (i.e. `rustls`).

Some advanced methods are been removed, such as: `token_key` and `enable_key_log` in the spirit of the mission of `wtransport`: having a minimal and user-friendly API. However, providing (with a single method) the configuration via `quinn` and `rustls` all advanced configurations are still possible.

This PR also changes `DnsResolver` interface: it simplifies the code and avoid usage of a `Mutex` for DNS resolution