### PR TITLE
deps: update to `quinn@0.11.5` (patched).

### DIFF
--- a/wtransport/Cargo.toml
+++ b/wtransport/Cargo.toml
@@ -31,7 +31,7 @@ required-features = ["self-signed"]
 [dependencies]
 bytes = "1.4.0"
 pem = "3.0.4"
-quinn = { version = "0.11.3", default-features = false, features = ["runtime-tokio", "rustls"] }
+quinn = { version = "0.11.5", default-features = false, features = ["runtime-tokio", "rustls"] }
 rcgen = { version = "0.13.1", optional = true }
 rustls = { version = "0.23.12", default-features = false, features = ["ring"] }
 rustls-native-certs = "0.8.0"


### PR DESCRIPTION
Update to a version of `quinn` that enforces a version of `quinn-proto` that is patched against [ CVE-2024-45311](https://github.com/quinn-rs/quinn/security/advisories/GHSA-vr26-jcq5-fjj8#advisory-comment-108846).