### PR TITLE
cargo: bump packages version 0.2.0 -> 0.3.0

### DIFF
--- a/wtransport-proto/Cargo.toml
+++ b/wtransport-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wtransport-proto"
-version = "0.2.0"
+version = "0.3.0"
 license = "MIT OR Apache-2.0"
 authors = ["Biagio Festa"]
 description = "Implementation of the WebTransport (over HTTP3) protocol"

--- a/wtransport/Cargo.toml
+++ b/wtransport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wtransport"
-version = "0.2.0"
+version = "0.3.0"
 license = "MIT OR Apache-2.0"
 authors = ["Biagio Festa"]
 description = "Implementation of the WebTransport (over HTTP3) protocol"
@@ -44,7 +44,7 @@ time = "0.3.21"
 tokio = { version = "1.28.1", default-features = false, features = ["macros", "fs", "io-util"] }
 tracing = "0.1.37"
 url = "2.4.0"
-wtransport-proto = { version = "0.2.0", path = "../wtransport-proto", features = ["async"] }
+wtransport-proto = { version = "0.3.0", path = "../wtransport-proto", features = ["async"] }
 x509-parser = "0.16.0"
 
 [dev-dependencies]


### PR DESCRIPTION
* New release due to: [quinn/CVE-2024-45311](https://github.com/quinn-rs/quinn/security/advisories/GHSA-vr26-jcq5-fjj8)
* Major bump is required because of: https://github.com/BiagioFesta/wtransport/commit/f7e0374403aef026537d2dae208e159b24213b03
