### PR TITLE
examples: fix mismatched argument type

### DIFF
--- a/wtransport/examples/full.rs
+++ b/wtransport/examples/full.rs
@@ -460,7 +460,7 @@ async function sendData() {
       case 'bidi': {
         let stream = await transport.createBidirectionalStream();
         let number = streamNumber++;
-        readFromIncomingStream(stream, number);
+        readFromIncomingStream(stream.readable, number);
 
         let writer = stream.writable.getWriter();
         await writer.write(data);


### PR DESCRIPTION
Fixes #219

## Description

`createBidirectionalStream` returns not `WebTransportReceiveStream` but `WebTransportBidirectionalStream`.

So, We have to pass `.readable`

ref: https://developer.mozilla.org/en-US/docs/Web/API/WebTransportBidirectionalStream
ref: [w3c/webtransport/samples/echo/client.js#72](https://github.com/w3c/webtransport/blob/3363834b7fcd5854aa8ef47c62881d9bf8c4eb2b/samples/echo/client.js#L72)

## Test

```sh
cargo run --example full
```

1. Click `Connect`
2. Select `Open a bidirectional stream`
3. Click `Send data` -> Receive ACK