### PR TITLE
Add Debug, Clone, and accessors on `ConnectOptions`

### DIFF
--- a/wtransport/src/endpoint.rs
+++ b/wtransport/src/endpoint.rs
@@ -465,6 +465,7 @@ impl Endpoint<endpoint_side::Client> {
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Debug, Clone)]
 pub struct ConnectOptions {
     url: String,
     additional_headers: HashMap<String, String>,
@@ -489,6 +490,16 @@ impl ConnectOptions {
             url: url.to_string(),
             additional_headers: Default::default(),
         }
+    }
+
+    /// Gets the URL which this will connect to.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Gets the additional headers that will be passed when connecting.
+    pub fn additional_headers(&self) -> &HashMap<String, String> {
+        &self.additional_headers
     }
 }
 


### PR DESCRIPTION
Right now `ConnectOptions` is effectively opaque, but I want to inspect it after creation so I can log the URL that it connects to. The user of my crate creates and passes their own `ConnectOptions`, so I'm unable to read the URL before creation.

This PR derives `Debug` so that it can be debug printed, and adds `url` and `additional_headers` read-only accessor fields. It also derives `Clone` so that I can reuse the options for later.

IMO, these two fields should just be public. I don't see a reason to keep them private since this struct is just a data container. But for consistency with the rest of the API, and to allow extending `ConnectOptions` in the future without breaking existing code, I've just written accessors for the fields individually.