### PR TITLE
Expose `quinn::EndpointConfig` for `{Client,Server}Config`

### DIFF
--- a/wtransport/Cargo.toml
+++ b/wtransport/Cargo.toml
@@ -74,6 +74,7 @@ allowed_external_types = [
     "quinn::send_stream::SendStream",
     "quinn::send_stream::WriteError",
     "quinn_proto::config::ClientConfig",
+    "quinn_proto::config::EndpointConfig",
     "quinn_proto::config::ServerConfig",
     "quinn_proto::config::TransportConfig",
     "quinn_proto::connection::ConnectionError",

--- a/wtransport/src/endpoint.rs
+++ b/wtransport/src/endpoint.rs
@@ -153,17 +153,14 @@ impl<Side> Endpoint<Side> {
 impl Endpoint<endpoint_side::Server> {
     /// Constructs a *server* endpoint.
     pub fn server(server_config: ServerConfig) -> std::io::Result<Self> {
+        let endpoint_config = server_config.endpoint_config;
         let quic_config = server_config.quic_config;
         let socket =
             Self::bind_socket(server_config.bind_address, server_config.dual_stack_config)?;
         let runtime = Arc::new(TokioRuntime);
 
-        let endpoint = quinn::Endpoint::new(
-            quinn::EndpointConfig::default(),
-            Some(quic_config),
-            socket.into(),
-            runtime,
-        )?;
+        let endpoint =
+            quinn::Endpoint::new(endpoint_config, Some(quic_config), socket.into(), runtime)?;
 
         Ok(Self {
             endpoint,
@@ -213,17 +210,13 @@ impl Endpoint<endpoint_side::Server> {
 impl Endpoint<endpoint_side::Client> {
     /// Constructs a *client* endpoint.
     pub fn client(client_config: ClientConfig) -> std::io::Result<Self> {
+        let endpoint_config = client_config.endpoint_config;
         let quic_config = client_config.quic_config;
         let socket =
             Self::bind_socket(client_config.bind_address, client_config.dual_stack_config)?;
         let runtime = Arc::new(TokioRuntime);
 
-        let mut endpoint = quinn::Endpoint::new(
-            quinn::EndpointConfig::default(),
-            None,
-            socket.into(),
-            runtime,
-        )?;
+        let mut endpoint = quinn::Endpoint::new(endpoint_config, None, socket.into(), runtime)?;
 
         endpoint.set_default_client_config(quic_config);
 


### PR DESCRIPTION
This PR exposes the `quinn::EndpointConfig` via `quic_endpoint_config`/`quic_endpoint_config_mut` on `ClientConfig`/`ServerConfig`, analogously to how `quinn::{Client,Server}` are currently exposed.

To give a bit of context to the use case: I'd like to manually manage connection IDs on the application level and would like to set the [`EndpointConfig::cid_generator`](https://github.com/quinn-rs/quinn/blob/ead9b9316c155073c0984a243aeb9b84c5465298/quinn-proto/src/config.rs#L651-L665) for that purpose.

If you have another proposal on how to expose this or don't like to expose it all, let me know. I just figured opening this PR was as quick as opening a discussion on what I'd like to change.