### PR TITLE
No awaiting finish on supposed-to-be already finished connect_stream

### DIFF
--- a/wtransport/src/driver/mod.rs
+++ b/wtransport/src/driver/mod.rs
@@ -313,7 +313,6 @@ mod worker {
                 DriverError::ApplicationClosed(_) => {
                     // Termination procedure
                     // TODO Reset send sides of all streams with SessionGone error
-                    self.connect_stream.finish().await;
                     self.quic_connection
                         .close(varint_w2q(ErrorCode::NoError.to_code()), b"");
                 }

--- a/wtransport/src/driver/streams/connect.rs
+++ b/wtransport/src/driver/streams/connect.rs
@@ -60,6 +60,12 @@ impl ConnectStream {
                             Err(error_code) => return DriverError::Proto(error_code),
                         };
 
+                    // reset right away to avoid receiving additional data which requires resetting with ErrorCode::Message.
+                    self.stream
+                        .take()
+                        .unwrap()
+                        .reset(ErrorCode::NoError.to_code());
+
                     DriverError::ApplicationClosed(ApplicationClose::new(
                         close_session.error_code(),
                         close_session
@@ -84,15 +90,5 @@ impl ConnectStream {
                 },
             };
         }
-    }
-
-    /// Finishes termination process.
-    pub async fn finish(mut self) {
-        let Some(mut stream) = self.stream.take() else {
-            return;
-        };
-
-        // Finish our side and wait for confirmation.
-        stream.finish().await;
     }
 }

--- a/wtransport/src/driver/streams/mod.rs
+++ b/wtransport/src/driver/streams/mod.rs
@@ -551,6 +551,10 @@ pub mod session {
         pub async fn finish(&mut self) {
             let _ = self.stream.0.finish().await;
         }
+
+        pub fn reset(&mut self, error_code: VarInt) {
+            let _ = self.stream.0.reset(error_code);
+        }
     }
 }
 


### PR DESCRIPTION
As discussed in #239, "finish means finish". Otherwise, when the client closes the connection, the server keeps waiting until max idle timeout.