### PR TITLE
Use `reset` instead of `finish`

### DIFF
--- a/wtransport/src/driver/mod.rs
+++ b/wtransport/src/driver/mod.rs
@@ -313,7 +313,7 @@ mod worker {
                 DriverError::ApplicationClosed(_) => {
                     // Termination procedure
                     // TODO Reset send sides of all streams with SessionGone error
-                    self.connect_stream.finish().await;
+                    self.connect_stream.finish();
                     self.quic_connection
                         .close(varint_w2q(ErrorCode::NoError.to_code()), b"");
                 }

--- a/wtransport/src/driver/streams/connect.rs
+++ b/wtransport/src/driver/streams/connect.rs
@@ -87,12 +87,13 @@ impl ConnectStream {
     }
 
     /// Finishes termination process.
-    pub async fn finish(mut self) {
+    pub fn finish(mut self) {
         let Some(mut stream) = self.stream.take() else {
             return;
         };
 
-        // Finish our side and wait for confirmation.
-        stream.finish().await;
+        // Notify other side.
+        // We can safely ignore error since we already know we are shuting down.
+        let _ = stream.reset(VarInt::from_u32(0));
     }
 }

--- a/wtransport/src/driver/streams/mod.rs
+++ b/wtransport/src/driver/streams/mod.rs
@@ -551,6 +551,10 @@ pub mod session {
         pub async fn finish(&mut self) {
             let _ = self.stream.0.finish().await;
         }
+
+        pub fn reset(&mut self, error_code: VarInt) -> Result<(), ClosedStream> {
+            self.stream.0.reset(error_code)
+        }
     }
 }
 


### PR DESCRIPTION
Addresses reported issue https://github.com/BiagioFesta/wtransport/issues/197#issuecomment-2651872385 by resetting connect stream instead of finishing it which is valid under current rfc.