### PR TITLE
Fix #257: Return except exercise frame

### DIFF
--- a/wtransport-proto/src/frame.rs
+++ b/wtransport-proto/src/frame.rs
@@ -63,7 +63,7 @@ pub type IoWriteError = bytes::IoWriteError;
 pub type FrameOwned = Frame<'static>;
 
 /// An HTTP3 [`Frame`] type.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum FrameKind {
     /// DATA frame type.
     Data,

--- a/wtransport/src/driver/mod.rs
+++ b/wtransport/src/driver/mod.rs
@@ -497,18 +497,25 @@ mod worker {
                 async move {
                     let mut stream_h3 = stream_quic.upgrade();
 
-                    let frame = match stream_h3.read_frame().await {
-                        Ok(frame) => frame,
-                        Err(ProtoReadError::H3(error_code)) => {
-                            h3_slot.send(Err(DriverError::Proto(error_code)));
-                            return;
-                        }
-                        Err(ProtoReadError::IO(_)) => {
-                            return;
+                    let frame = loop {
+                        match stream_h3.read_frame().await {
+                            Ok(frame) => {
+                                debug!("Frame kind: {:?}", frame.kind());
+                                if !matches!(frame.kind(), FrameKind::Exercise(_)) {
+                                    break frame; 
+                                }
+                            }
+                            Err(ProtoReadError::H3(error_code)) => {
+                                h3_slot.send(Err(DriverError::Proto(error_code)));
+                                return;
+                            }
+                            Err(ProtoReadError::IO(_)) => {
+                                return;
+                            }
                         }
                     };
 
-                    debug!("First frame kind: {:?}", frame.kind());
+                    debug!("First frame: {:?}", frame);
 
                     match frame.session_id() {
                         Some(session_id) => {


### PR DESCRIPTION
This PR addresses the issue in issue #257.

Changed to ignore Exercise frames in response to WebTransport implementations that send Exercise frames before Header frames.

This allows proxygen and wtransport to make WebTransport connections.
