### PR TITLE
Fix `clippy::uninlined_format_args` lints

### DIFF
--- a/wtransport-proto/src/session.rs
+++ b/wtransport-proto/src/session.rs
@@ -141,7 +141,7 @@ impl SessionRequest {
         let path = format!(
             "{}{}",
             url.path(),
-            url.query().map(|s| format!("?{}", s)).unwrap_or_default()
+            url.query().map(|s| format!("?{s}")).unwrap_or_default()
         );
 
         let headers = [

--- a/wtransport/src/error.rs
+++ b/wtransport/src/error.rs
@@ -329,7 +329,7 @@ impl Display for QuicProtoError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let code = self
             .code
-            .map(|code| format!(" (code: {})", code))
+            .map(|code| format!(" (code: {code})"))
             .unwrap_or_default();
 
         f.write_fmt(format_args!("{}{}", self.reason, code))

--- a/wtransport/src/tls.rs
+++ b/wtransport/src/tls.rs
@@ -509,7 +509,7 @@ impl Sha256Digest {
             Sha256DigestFmt::DottedHex => self
                 .0
                 .iter()
-                .map(|byte| format!("{:02x}", byte))
+                .map(|byte| format!("{byte:02x}"))
                 .collect::<Vec<_>>()
                 .join(":"),
         }


### PR DESCRIPTION
These are enabled in nightly clippy now.