### PR TITLE
Fix `mismatched_lifetime_syntaxes` warnings by adding explicitly elided lifetimes

### DIFF
--- a/wtransport-proto/src/bytes.rs
+++ b/wtransport-proto/src/bytes.rs
@@ -418,7 +418,7 @@ pub mod r#async {
     #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
     pub trait BytesReaderAsync {
         /// Reads an unsigned variable-length integer in network byte-order from a source.
-        fn get_varint(&mut self) -> GetVarint<Self>;
+        fn get_varint(&mut self) -> GetVarint<'_, Self>;
 
         /// Reads the source until `buffer` is completely filled.
         fn get_buffer<'a>(&'a mut self, buffer: &'a mut [u8]) -> GetBuffer<'a, Self>;
@@ -428,7 +428,7 @@ pub mod r#async {
     where
         T: AsyncRead + ?Sized,
     {
-        fn get_varint(&mut self) -> GetVarint<Self> {
+        fn get_varint(&mut self) -> GetVarint<'_, Self> {
             GetVarint::new(self)
         }
 
@@ -441,7 +441,7 @@ pub mod r#async {
     where
         T: AsyncWrite + ?Sized,
     {
-        fn put_varint(&mut self, varint: VarInt) -> PutVarint<Self> {
+        fn put_varint(&mut self, varint: VarInt) -> PutVarint<'_, Self> {
             PutVarint::new(self, varint)
         }
 
@@ -455,7 +455,7 @@ pub mod r#async {
     pub trait BytesWriterAsync {
         /// Writes an unsigned variable-length integer in network byte-order to
         /// the source advancing the buffer's internal cursor.
-        fn put_varint(&mut self, varint: VarInt) -> PutVarint<Self>;
+        fn put_varint(&mut self, varint: VarInt) -> PutVarint<'_, Self>;
 
         /// Pushes some bytes into the source advancing the buffer’s internal cursor.
         fn put_buffer<'a>(&'a mut self, buffer: &'a [u8]) -> PutBuffer<'a, Self>;

--- a/wtransport-proto/src/datagram.rs
+++ b/wtransport-proto/src/datagram.rs
@@ -183,7 +183,7 @@ mod tests {
         }
 
         /// This function is for **testing purpose only**; it might produce an invalid `Datagram`!
-        pub fn build_datagram(qstream_id_type: QStreamIdType, payload: &[u8]) -> Datagram {
+        pub fn build_datagram(qstream_id_type: QStreamIdType, payload: &[u8]) -> Datagram<'_> {
             Datagram::new(qstream_id_type.into_session_id(), payload)
         }
     }

--- a/wtransport-proto/src/frame.rs
+++ b/wtransport-proto/src/frame.rs
@@ -703,7 +703,7 @@ mod tests {
         }
 
         #[cfg(feature = "async")]
-        pub async fn assert_serde_async(frame: Frame<'_>) -> Frame {
+        pub async fn assert_serde_async(frame: Frame<'_>) -> Frame<'_> {
             let mut buffer = Vec::new();
 
             frame.write_async(&mut buffer).await.unwrap();

--- a/wtransport-proto/src/settings.rs
+++ b/wtransport-proto/src/settings.rs
@@ -144,7 +144,7 @@ impl Settings {
     ///
     /// This function allocates heap-memory, producing a [`Frame`] with owned payload.
     /// See [`Self::generate_frame_ref`] for a version without inner memory allocation.
-    pub fn generate_frame(&self) -> Frame {
+    pub fn generate_frame(&self) -> Frame<'_> {
         let mut payload = Vec::new();
 
         for (id, value) in &self.0 {


### PR DESCRIPTION
This makes wtransport build warning-free on current Rust.
