### PR TITLE
Fix cargo-check-external-types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2025-05-04
+          toolchain: nightly-2025-08-06
       - name: Setup
-        run: cargo install cargo-check-external-types --locked
+        run: cargo install cargo-check-external-types@0.3.0 --locked
       - name: Check Ext Types (wtransport)
         working-directory: wtransport/
         run: cargo check-external-types --all-features


### PR DESCRIPTION
Use a matching nightly version, and pin the version of
cargo-check-external-types to avoid future breakage due to a mismatched
nightly version.
