### PR TITLE
Drop nightly doc CI job (currently broken)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup
-        run: rustup toolchain install nightly
-      - name: Doc (stable)
+      - name: Doc
         run: cargo doc --all-features
-      - name: Doc (nightly)
-        run: RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
 
   check-external-types:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The nightly doc job enables the `docsrs` feature on dependencies, which
causes breakage in the ecosystem when changes occur in the corresponding
nightly features. Drop the CI job.

(An alternative to this would be to enable `docsrs` *only* for the wtransport
crates and not all dependencies.)
