### PR TITLE
feat(endpoint): add accept_from_connection method

### DIFF
--- a/wtransport/src/endpoint.rs
+++ b/wtransport/src/endpoint.rs
@@ -591,7 +591,12 @@ impl IncomingSessionFuture {
 
     async fn accept(quic_incoming: quinn::Incoming) -> Result<SessionRequest, ConnectionError> {
         let quic_connection = quic_incoming.await?;
+        Self::accept_from_connection(quic_connection).await
+    }
 
+    pub async fn accept_from_connection(
+        quic_connection: quinn::Connection,
+    ) -> Result<SessionRequest, ConnectionError> {
         let driver = Driver::init(quic_connection.clone());
 
         let _settings = driver.accept_settings().await.map_err(|driver_error| {


### PR DESCRIPTION
### Summary

Add a public accept_from_connection method to IncomingSessionFuture that accepts an
existing quinn::Connection directly.

This allows users to create a SessionRequest from a QUIC connection they already hold,
enabling more flexible integration scenarios where the connection lifecycle is managed
externally.

### Use case

This is useful when you want to use raw Quinn alongside wtransport on the same port. You
can inspect the incoming QUIC connection first (e.g., check ALPN), then decide whether to
handle it as a raw Quinn connection or pass it to wtransport for WebTransport session
handling.