### PR TITLE
feat(endpoint): add accept_with_headers to SessionRequest

### DIFF
--- a/wtransport/src/endpoint.rs
+++ b/wtransport/src/endpoint.rs
@@ -701,7 +701,7 @@ impl SessionRequest {
         self.stream_session.request().headers().as_ref()
     }
 
-    /// Accepts the client request with some headers and it establishes the WebTransport session.
+    /// Accepts the client request with headers.
     pub async fn accept_with_headers<I, K, V>(
         self,
         headers: I,
@@ -711,7 +711,7 @@ impl SessionRequest {
         K: Into<String>,
         V: Into<String>,
     {
-        self._accept(Some(
+        self.accept_impl(Some(
             headers
                 .into_iter()
                 .map(|(k, v)| (k.into(), v.into()))
@@ -722,7 +722,7 @@ impl SessionRequest {
 
     /// Accepts the client request and it establishes the WebTransport session.
     pub async fn accept(self) -> Result<Connection, ConnectionError> {
-        self._accept(None).await
+        self.accept_impl(None).await
     }
 
     /// Rejects the client request by replying with `403` status code.
@@ -740,7 +740,7 @@ impl SessionRequest {
         self.reject(SessionResponseProto::too_many_requests()).await;
     }
 
-    async fn _accept(
+    async fn accept_impl(
         mut self,
         headers: Option<HashMap<String, String>>,
     ) -> Result<Connection, ConnectionError> {

--- a/wtransport/src/endpoint.rs
+++ b/wtransport/src/endpoint.rs
@@ -701,9 +701,56 @@ impl SessionRequest {
         self.stream_session.request().headers().as_ref()
     }
 
+    /// Accepts the client request with some headers and it establishes the WebTransport session.
+    pub async fn accept_with_headers<I, K, V>(
+        self,
+        headers: I,
+    ) -> Result<Connection, ConnectionError>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self._accept(Some(
+            headers
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        ))
+        .await
+    }
+
     /// Accepts the client request and it establishes the WebTransport session.
-    pub async fn accept(mut self) -> Result<Connection, ConnectionError> {
-        let response = SessionResponseProto::ok();
+    pub async fn accept(self) -> Result<Connection, ConnectionError> {
+        self._accept(None).await
+    }
+
+    /// Rejects the client request by replying with `403` status code.
+    pub async fn forbidden(self) {
+        self.reject(SessionResponseProto::forbidden()).await;
+    }
+
+    /// Rejects the client request by replying with `404` status code.
+    pub async fn not_found(self) {
+        self.reject(SessionResponseProto::not_found()).await;
+    }
+
+    /// Rejects the client request by replying with `429` status code.
+    pub async fn too_many_requests(self) {
+        self.reject(SessionResponseProto::too_many_requests()).await;
+    }
+
+    async fn _accept(
+        mut self,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<Connection, ConnectionError> {
+        let mut response = SessionResponseProto::ok();
+
+        if let Some(headers) = headers {
+            for (key, value) in headers {
+                response.add(key, value);
+            }
+        }
 
         self.send_response(response).await?;
 
@@ -721,21 +768,6 @@ impl SessionRequest {
             self.driver,
             session_id,
         ))
-    }
-
-    /// Rejects the client request by replying with `403` status code.
-    pub async fn forbidden(self) {
-        self.reject(SessionResponseProto::forbidden()).await;
-    }
-
-    /// Rejects the client request by replying with `404` status code.
-    pub async fn not_found(self) {
-        self.reject(SessionResponseProto::not_found()).await;
-    }
-
-    /// Rejects the client request by replying with `429` status code.
-    pub async fn too_many_requests(self) {
-        self.reject(SessionResponseProto::too_many_requests()).await;
     }
 
     async fn reject(mut self, response: SessionResponseProto) {

--- a/wtransport/src/endpoint.rs
+++ b/wtransport/src/endpoint.rs
@@ -711,18 +711,18 @@ impl SessionRequest {
         K: Into<String>,
         V: Into<String>,
     {
-        self.accept_impl(Some(
+        self.accept_impl(
             headers
                 .into_iter()
                 .map(|(k, v)| (k.into(), v.into()))
                 .collect(),
-        ))
+        )
         .await
     }
 
     /// Accepts the client request and it establishes the WebTransport session.
     pub async fn accept(self) -> Result<Connection, ConnectionError> {
-        self.accept_impl(None).await
+        self.accept_impl(HashMap::new()).await
     }
 
     /// Rejects the client request by replying with `403` status code.
@@ -742,14 +742,12 @@ impl SessionRequest {
 
     async fn accept_impl(
         mut self,
-        headers: Option<HashMap<String, String>>,
+        headers: HashMap<String, String>,
     ) -> Result<Connection, ConnectionError> {
         let mut response = SessionResponseProto::ok();
 
-        if let Some(headers) = headers {
-            for (key, value) in headers {
-                response.add(key, value);
-            }
+        for (key, value) in headers {
+            response.add(key, value);
         }
 
         self.send_response(response).await?;


### PR DESCRIPTION
Allows the server to include custom response headers when accepting an incoming WebTransport session. Headers can be passed as any iterable of key-value pairs.

In MOQtail relay, we need this feature to implement ALPN. 
Please see https://github.com/moqtail/moqtail/blob/f0852da4c6872aeabf53567987e0c0f2b4256146/apps/relay/src/server/session.rs#L90-L104